### PR TITLE
Small fixes

### DIFF
--- a/schema.d.ts
+++ b/schema.d.ts
@@ -68,7 +68,7 @@ export interface JavaScriptModule {
    * exports should be described here. Ie, functions and objects that may be
    * properties of exported objects, or passed as arguments to functions.
    */
-  declarations: Array<Declaration>;
+  declarations?: Array<Declaration>;
 
   /**
    * The exports of a module. This includes JavaScript exports and

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -245,7 +245,7 @@ export interface Attribute {
    * As attributes are always strings, this is the actual value, not a human
    * readable description.
    */
-  defaultValue?: string;
+  default?: string;
 
   /**
    * The name of the field this attribute is associated with, if any.
@@ -314,7 +314,7 @@ export interface CssCustomProperty {
    */
   name: string;
 
-  defaultValue?: string;
+  default?: string;
 
   /**
    * A markdown summary suitable for display in a listing.


### PR DESCRIPTION
- Align `default` and `defaultValue`s throughout the manifest. We use `default` for fields, but `defaultValue` for css properties and attributes. Also avoids [awkward code](https://github.com/storybookjs/storybook/blob/next/addons/docs/src/frameworks/web-components/custom-elements.ts#L51) in Storybook
- Declarations are optional; if a module doesn't export anything (but maybe runs a side effect for example), declarations will be empty. Or said differently; `exports` are optional, but if a module doesnt have any `exports`, there also aren't any declarations to list.