### PR TITLE
Add syntax field to CSSCustomProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ## [x.y.z] - YYYY-MM-DD -->
 ## Unreleased
 <!-- ### Changed -->
-<!-- ### Added -->
+### Added
+
+- Added an optional `"syntax"` field to CSSCustomProperty to descript the property syntax using CSS Properties and Values API's syntax strings. Fixes
+https://github.com/webcomponents/custom-elements-manifest/issues/68
+
 <!-- ### Removed -->
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Changed -->
 ### Added
 
-- Added an optional `"syntax"` field to CSSCustomProperty to descript the property syntax using CSS Properties and Values API's syntax strings. Fixes
+- Added an optional `"syntax"` field to CSSCustomProperty to describe the property syntax using CSS Properties and Values API's syntax strings. Fixes
 https://github.com/webcomponents/custom-elements-manifest/issues/68
 
 <!-- ### Removed -->

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -323,6 +323,14 @@ export interface CssCustomProperty {
    */
   name: string;
 
+  /**
+   * The expected syntax of the defined property. Defaults to "*".
+   *
+   * The syntax must be a valid CSS [syntax string](https://drafts.css-houdini.org/css-properties-values-api/#syntax-string)
+   * as defined in the CSS Properties and Values API.
+   */
+  syntax?: string;
+
   default?: string;
 
   /**
@@ -541,8 +549,9 @@ export interface MixinDeclaration extends ClassLike, FunctionLike {
 /**
  * A class mixin that also adds custom element related properties.
  */
-export interface CustomElementMixinDeclaration extends MixinDeclaration, CustomElement {
-}
+export interface CustomElementMixinDeclaration
+  extends MixinDeclaration,
+    CustomElement {}
 
 export interface VariableDeclaration extends PropertyLike {
   kind: 'variable';

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -326,8 +326,15 @@ export interface CssCustomProperty {
   /**
    * The expected syntax of the defined property. Defaults to "*".
    *
-   * The syntax must be a valid CSS [syntax string](https://drafts.css-houdini.org/css-properties-values-api/#syntax-string)
+   * The syntax must be a valid CSS [syntax string](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax)
    * as defined in the CSS Properties and Values API.
+   * 
+   * Examples:
+   * 
+   * "<color>": accepts a color
+   * "<length> | <percentage>": accepts lengths or percentages but not calc expressions with a combination of the two
+   * "small | medium | large": accepts one of these values set as custom idents.
+   * "*": any valid token
    */
   syntax?: string;
 


### PR DESCRIPTION
Fixes https://github.com/webcomponents/custom-elements-manifest/issues/68

The documentation on the field is sparse and just points to the CSS Properties and Values API spec [definition of "syntax string"](https://drafts.css-houdini.org/css-properties-values-api/#syntax-string) because I couldn't find a more readable doc to reference. We should try to add a more readable description of the syntax string or find a better resource to link to.