### PR TITLE
Add InterfaceDeclaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added an optional `"syntax"` field to CSSCustomProperty to describe the property syntax using CSS Properties and Values API's syntax strings. Fixes
 https://github.com/webcomponents/custom-elements-manifest/issues/68
 
+- Added InterfaceDeclaration. Fixes https://github.com/webcomponents/custom-elements-manifest/issues/76
+
 <!-- ### Removed -->
 ### Fixed
 

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -132,7 +132,8 @@ export type Declaration =
   | MixinDeclaration
   | VariableDeclaration
   | CustomElementDeclaration
-  | CustomElementMixinDeclaration;
+  | CustomElementMixinDeclaration
+  | InterfaceDeclaration;
 
 /**
  * A reference to an export of a module.
@@ -384,6 +385,34 @@ export interface Type {
 export interface TypeReference extends Reference {
   start?: number;
   end?: number;
+}
+
+/**
+ * An interface that describes the properties and methods of an object.
+ */
+export interface InterfaceDeclaration {
+  kind: 'interface';
+
+  name: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description of the class.
+   */
+  description?: string;
+
+  /**
+   * The interfaces that this interface extends.
+   */
+  supertypes?: Array<Reference>;
+
+  members?: Array<ClassMember>;
+
+  source?: SourceReference;
 }
 
 /**


### PR DESCRIPTION
Fixes #76 

InterfaceDeclaration is very similar to ClassDeclaration but doesn't imply a constructor and replaces `superclass` and `mixins` with `supertypes`.