### PR TITLE
Fix schema to include CustomElementDeclaration and CustomElementMixinDeclaration

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,5 @@
 name: Test
+
 on:
   push:
     branches: [ main ]
@@ -17,3 +18,5 @@ jobs:
       - run: npm run build
       - name: Check schema.json is up-to-date
         run: git diff --exit-code
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,19 @@
+name: Test
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm run build
+      - name: Check schema.json is up-to-date
+        run: git diff --exit-code

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules/
+/test/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .DS_Store
 node_modules/
-schema.json

--- a/examples/simple-element.json
+++ b/examples/simple-element.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "README.md",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "my-project/my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "This is the description of the class",
+          "name": "MyElement",
+          "members": [
+            {
+              "kind": "field",
+              "name": "disabled"
+            },
+            {
+              "kind": "method",
+              "name": "fire"
+            }
+          ],
+          "events": [
+            {
+              "name": "disabled-changed",
+              "type": {
+                "text": "Event"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "disabled"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "my-element",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "MyElement",
+          "declaration": {
+            "name": "MyElement",
+            "module": "my-project/my-element.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "my-element",
+          "declaration": {
+            "name": "MyElement",
+            "module": "my-project/my-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
+        "jsonschema": "^1.4.0",
         "prettier": "^2.2.1",
         "typescript": "~4.5.5",
-        "typescript-json-schema": "^0.53.0"
+        "typescript-json-schema": "^0.53.0",
+        "uvu": "^0.5.3"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {
@@ -179,6 +181,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -263,6 +274,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/jsonschema": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
+      "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -279,6 +308,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/once": {
@@ -318,6 +356,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/safe-stable-stringify": {
@@ -426,6 +476,33 @@
       },
       "bin": {
         "typescript-json-schema": "bin/typescript-json-schema"
+      }
+    },
+    "node_modules/uvu": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.3.tgz",
+      "integrity": "sha512-brFwqA3FXzilmtnIyJ+CxdkInkY/i4ErvP7uV0DnUVxQcQ55reuHphorpF+tZoVHK2MniZ/VJzI7zJQoc9T9Yw==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      },
+      "bin": {
+        "uvu": "bin.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/uvu/node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -642,6 +719,12 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+      "dev": true
+    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -708,6 +791,18 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
+    "jsonschema": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
+      "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==",
+      "dev": true
+    },
+    "kleur": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+      "dev": true
+    },
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -722,6 +817,12 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -749,6 +850,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
+    },
+    "sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "requires": {
+        "mri": "^1.1.0"
+      }
     },
     "safe-stable-stringify": {
       "version": "2.3.1",
@@ -816,6 +926,26 @@
         "ts-node": "^10.2.1",
         "typescript": "~4.5.0",
         "yargs": "^17.1.1"
+      }
+    },
+    "uvu": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.3.tgz",
+      "integrity": "sha512-brFwqA3FXzilmtnIyJ+CxdkInkY/i4ErvP7uV0DnUVxQcQ55reuHphorpF+tZoVHK2MniZ/VJzI7zJQoc9T9Yw==",
+      "dev": true,
+      "requires": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
+        }
       }
     },
     "v8-compile-cache-lib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,576 @@
 {
   "name": "custom-elements-manifest",
-  "version": "0.1.0",
-  "lockfileVersion": 1,
+  "version": "1.0.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "custom-elements-manifest",
+      "version": "1.0.0",
+      "license": "BSD-3-Clause",
+      "devDependencies": {
+        "prettier": "^2.2.1",
+        "typescript": "~4.5.5",
+        "typescript-json-schema": "^0.53.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "16.11.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.24.tgz",
+      "integrity": "sha512-Ezv33Rl4mIi6YdSHfIRNBd4Q9kUe5okiaw/ikvJiJDmuQZNW5kfdg7+oQPF8NO6sTcr3woIpj3jANzTXdvEZXA==",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
+      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.5.0.tgz",
+      "integrity": "sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.0",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/typescript-json-schema": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.53.0.tgz",
+      "integrity": "sha512-BcFxC9nipQQOXxrBGI/jOWU31BwzVh6vqJR008G8VHKJtQ8YrZX6veriXfTK1l+L0/ff0yKl3mZigMLA6ZqkHg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@types/node": "^16.9.2",
+        "glob": "^7.1.7",
+        "safe-stable-stringify": "^2.2.0",
+        "ts-node": "^10.2.1",
+        "typescript": "~4.5.0",
+        "yargs": "^17.1.1"
+      },
+      "bin": {
+        "typescript-json-schema": "bin/typescript-json-schema"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
   "dependencies": {
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
     "@types/json-schema": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "16.11.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.24.tgz",
+      "integrity": "sha512-Ezv33Rl4mIi6YdSHfIRNBd4Q9kUe5okiaw/ikvJiJDmuQZNW5kfdg7+oQPF8NO6sTcr3woIpj3jANzTXdvEZXA==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -32,9 +589,9 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "brace-expansion": {
@@ -46,12 +603,6 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
-    },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
     },
     "cliui": {
       "version": "7.0.4",
@@ -122,9 +673,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -157,21 +708,6 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
-    },
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -179,9 +715,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
+      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -203,9 +739,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
     },
     "require-directory": {
@@ -214,75 +750,79 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+    "safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
       "dev": true
     },
-    "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       }
     },
     "strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.5.0.tgz",
+      "integrity": "sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==",
       "dev": true,
       "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "v8-compile-cache-lib": "^3.0.0",
         "yn": "3.1.1"
       }
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "typescript-json-schema": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.49.0.tgz",
-      "integrity": "sha512-PumZkTmEE3T8TVyoJU6ZCp3K6VCmCb3Ei6fUaRIuDsIzYtmdJc6jV1D0RyBe5sd5mJ1iB6Zckm4KAKbqXs9oDw==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.53.0.tgz",
+      "integrity": "sha512-BcFxC9nipQQOXxrBGI/jOWU31BwzVh6vqJR008G8VHKJtQ8YrZX6veriXfTK1l+L0/ff0yKl3mZigMLA6ZqkHg==",
       "dev": true,
       "requires": {
-        "@types/json-schema": "^7.0.6",
-        "glob": "^7.1.6",
-        "json-stable-stringify": "^1.0.1",
-        "ts-node": "^9.1.1",
-        "typescript": "^4.1.3",
-        "yargs": "^16.2.0"
+        "@types/json-schema": "^7.0.9",
+        "@types/node": "^16.9.2",
+        "glob": "^7.1.7",
+        "safe-stable-stringify": "^2.2.0",
+        "ts-node": "^10.2.1",
+        "typescript": "~4.5.0",
+        "yargs": "^17.1.1"
       }
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "7.0.0",
@@ -302,30 +842,30 @@
       "dev": true
     },
     "y18n": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
     },
     "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
       "dev": true,
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.0.0"
       }
     },
     "yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
       "dev": true
     },
     "yn": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/webcomponents/custom-elements-manifest#readme",
   "devDependencies": {
     "prettier": "^2.2.1",
-    "typescript": "^4.1.5",
-    "typescript-json-schema": "^0.49.0"
+    "typescript": "~4.5.5",
+    "typescript-json-schema": "^0.53.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,10 +2,14 @@
   "name": "custom-elements-manifest",
   "version": "1.0.0",
   "description": "A file format for describing custom elements",
+  "type": "module",
   "main": "schema.json",
   "scripts": {
-    "format": "prettier schema.d.ts --write",
-    "build": "typescript-json-schema --required --ignoreErrors schema.d.ts -o schema.json Package",
+    "format": "prettier schema.d.ts src/**/*.ts --write",
+    "build": "npm run build:ts && npm run build:schema",
+    "build:ts": "tsc",
+    "build:schema": "typescript-json-schema --required --ignoreErrors schema.d.ts -o schema.json Package",
+    "test": "node ./test/schema_test.js",
     "prepublishOnly": "npm run build"
   },
   "files": [
@@ -24,8 +28,10 @@
   },
   "homepage": "https://github.com/webcomponents/custom-elements-manifest#readme",
   "devDependencies": {
+    "jsonschema": "^1.4.0",
     "prettier": "^2.2.1",
     "typescript": "~4.5.5",
-    "typescript-json-schema": "^0.53.0"
+    "typescript-json-schema": "^0.53.0",
+    "uvu": "^0.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "schema.json",
     "schema.d.ts"
   ],
+  "types": "schema.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/webcomponents/custom-elements-manifest.git"

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -208,7 +208,9 @@ export interface SourceReference {
  * tagName, and another `Module` should contain the
  * `CustomElementExport`.
  */
-export type CustomElementDeclaration = ClassDeclaration & CustomElement;
+// Note: this needs to be an interface to be included in the generated JSON
+// Schema output.
+export interface CustomElementDeclaration extends ClassDeclaration, CustomElement {}
 
 /**
  * The additional fields that a custom element adds to classes and mixins.
@@ -249,17 +251,7 @@ export interface CustomElement extends ClassLike {
    * custom element class
    */
   customElement: true;
-
-  members?: Array<CustomElementMember>;
-  
-  /**
-   * Whether the custom element is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: boolean|string;
 }
-
-export type CustomElementMember = CustomElementField | ClassMethod;
 
 export interface Attribute {
   name: string;
@@ -648,7 +640,9 @@ export interface MixinDeclaration extends ClassLike, FunctionLike {
 /**
  * A class mixin that also adds custom element related properties.
  */
-export type CustomElementMixinDeclaration = MixinDeclaration & CustomElement;
+// Note: this needs to be an interface to be included in the generated JSON
+// Schema output.
+export interface CustomElementMixinDeclaration extends MixinDeclaration, CustomElement {}
 
 export interface VariableDeclaration extends PropertyLike {
   kind: 'variable';

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -45,7 +45,7 @@ export interface Package {
    * Whether the package is deprecated.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: boolean|string;
+  deprecated?: boolean | string;
 }
 
 // This type may expand in the future to include JSON, CSS, or HTML
@@ -81,12 +81,12 @@ export interface JavaScriptModule {
    * custom element definitions.
    */
   exports?: Array<Export>;
-  
+
   /**
    * Whether the module is deprecated.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: boolean|string;
+  deprecated?: boolean | string;
 }
 
 export type Export = JavaScriptExport | CustomElementExport;
@@ -114,12 +114,12 @@ export interface JavaScriptExport {
    * defined and the `name` field must be `"*"`.
    */
   declaration: Reference;
-  
+
   /**
    * Whether the export is deprecated. For example, the name of the export was changed.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: boolean|string;
+  deprecated?: boolean | string;
 }
 
 /**
@@ -142,13 +142,13 @@ export interface CustomElementExport {
    * custom element.
    */
   declaration: Reference;
-  
+
   /**
    * Whether the custom-element export is deprecated.
    * For example, a future version will not register the custom element in this file.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: boolean|string;
+  deprecated?: boolean | string;
 }
 
 export type Declaration =
@@ -210,7 +210,9 @@ export interface SourceReference {
  */
 // Note: this needs to be an interface to be included in the generated JSON
 // Schema output.
-export interface CustomElementDeclaration extends ClassDeclaration, CustomElement {}
+export interface CustomElementDeclaration
+  extends ClassDeclaration,
+    CustomElement {}
 
 /**
  * The additional fields that a custom element adds to classes and mixins.
@@ -251,6 +253,14 @@ export interface CustomElement extends ClassLike {
    * custom element class
    */
   customElement: true;
+
+  // members?: Array<CustomElementMember>;
+
+  /**
+   * Whether the custom element is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
 }
 
 export interface Attribute {
@@ -285,12 +295,12 @@ export interface Attribute {
    * The name of the field this attribute is associated with, if any.
    */
   fieldName?: string;
-  
+
   /**
    * Whether the attribute is deprecated.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: boolean|string;
+  deprecated?: boolean | string;
 }
 
 export interface Event {
@@ -312,12 +322,12 @@ export interface Event {
   type: Type;
 
   inheritedFrom?: Reference;
-  
+
   /**
    * Whether the event is deprecated.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: boolean|string;
+  deprecated?: boolean | string;
 }
 
 export interface Slot {
@@ -335,12 +345,12 @@ export interface Slot {
    * A markdown description.
    */
   description?: string;
-  
+
   /**
    * Whether the slot is deprecated.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: boolean|string;
+  deprecated?: boolean | string;
 }
 
 /**
@@ -358,12 +368,12 @@ export interface CssPart {
    * A markdown description.
    */
   description?: string;
-  
+
   /**
    * Whether the CSS shadow part is deprecated.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: boolean|string;
+  deprecated?: boolean | string;
 }
 
 export interface CssCustomProperty {
@@ -398,12 +408,12 @@ export interface CssCustomProperty {
    * A markdown description.
    */
   description?: string;
-  
+
   /**
    * Whether the CSS custom property is deprecated.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: boolean|string;
+  deprecated?: boolean | string;
 }
 
 export interface Type {
@@ -506,12 +516,12 @@ export interface ClassLike {
   members?: Array<ClassMember>;
 
   source?: SourceReference;
-  
+
   /**
    * Whether the class or mixin is deprecated.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: boolean|string;
+  deprecated?: boolean | string;
 }
 
 export interface ClassDeclaration extends ClassLike {
@@ -540,12 +550,12 @@ export interface PropertyLike {
   type?: Type;
 
   default?: string;
-  
+
   /**
    * Whether the property is deprecated.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: boolean|string;
+  deprecated?: boolean | string;
 }
 
 export interface ClassField extends PropertyLike {
@@ -642,7 +652,9 @@ export interface MixinDeclaration extends ClassLike, FunctionLike {
  */
 // Note: this needs to be an interface to be included in the generated JSON
 // Schema output.
-export interface CustomElementMixinDeclaration extends MixinDeclaration, CustomElement {}
+export interface CustomElementMixinDeclaration
+  extends MixinDeclaration,
+    CustomElement {}
 
 export interface VariableDeclaration extends PropertyLike {
   kind: 'variable';

--- a/schema.json
+++ b/schema.json
@@ -269,8 +269,8 @@
             ],
             "type": "object"
         },
-        "CustomElement": {
-            "description": "The additional fields that a custom element adds to classes and mixins.",
+        "CustomElementDeclaration": {
+            "description": "A description of a custom element class.\n\nCustom elements are JavaScript classes, so this extends from\n`ClassDeclaration` and adds custom-element-specific features like\nattributes, events, and slots.\n\nNote that `tagName` in this interface is optional. Tag names are not\nneccessarily part of a custom element class, but belong to the definition\n(often called the \"registration\") or the `customElements.define()` call.\n\nBecause classes and tag names can only be registered once, there's a\none-to-one relationship between classes and tag names. For ease of use,\nwe allow the tag name here.\n\nSome packages define and register custom elements in separate modules. In\nthese cases one `Module` should contain the `CustomElement` without a\ntagName, and another `Module` should contain the\n`CustomElementExport`.",
             "properties": {
                 "attributes": {
                     "description": "The attributes that this element is known to understand.",
@@ -305,7 +305,7 @@
                     "type": "array"
                 },
                 "deprecated": {
-                    "description": "Whether the custom element is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "description": "Whether the class or mixin is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
                     "type": [
                         "string",
                         "boolean"
@@ -322,11 +322,17 @@
                     },
                     "type": "array"
                 },
+                "kind": {
+                    "enum": [
+                        "class"
+                    ],
+                    "type": "string"
+                },
                 "members": {
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/CustomElementField"
+                                "$ref": "#/definitions/ClassField"
                             },
                             {
                                 "$ref": "#/definitions/ClassMethod"
@@ -370,6 +376,7 @@
             },
             "required": [
                 "customElement",
+                "kind",
                 "name"
             ],
             "type": "object"
@@ -406,61 +413,130 @@
             ],
             "type": "object"
         },
-        "CustomElementField": {
-            "description": "Additional metadata for fields on custom elements.",
+        "CustomElementMixinDeclaration": {
+            "description": "A class mixin that also adds custom element related properties.",
             "properties": {
-                "attribute": {
-                    "description": "The corresponding attribute name if there is one.",
-                    "type": "string"
+                "attributes": {
+                    "description": "The attributes that this element is known to understand.",
+                    "items": {
+                        "$ref": "#/definitions/Attribute"
+                    },
+                    "type": "array"
                 },
-                "default": {
-                    "type": "string"
+                "cssParts": {
+                    "items": {
+                        "$ref": "#/definitions/CssPart"
+                    },
+                    "type": "array"
+                },
+                "cssProperties": {
+                    "items": {
+                        "$ref": "#/definitions/CssCustomProperty"
+                    },
+                    "type": "array"
+                },
+                "customElement": {
+                    "description": "Distinguishes a regular JavaScript class from a\ncustom element class",
+                    "enum": [
+                        true
+                    ],
+                    "type": "boolean"
+                },
+                "demos": {
+                    "items": {
+                        "$ref": "#/definitions/Demo"
+                    },
+                    "type": "array"
                 },
                 "deprecated": {
-                    "description": "Whether the property is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "description": "Whether the class or mixin is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
                     "type": [
                         "string",
                         "boolean"
                     ]
                 },
                 "description": {
-                    "description": "A markdown description of the field.",
+                    "description": "A markdown description of the class.",
                     "type": "string"
                 },
-                "inheritedFrom": {
-                    "$ref": "#/definitions/Reference"
+                "events": {
+                    "description": "The events that this element fires.",
+                    "items": {
+                        "$ref": "#/definitions/Event"
+                    },
+                    "type": "array"
                 },
                 "kind": {
                     "enum": [
-                        "field"
+                        "mixin"
                     ],
                     "type": "string"
+                },
+                "members": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/ClassField"
+                            },
+                            {
+                                "$ref": "#/definitions/ClassMethod"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "mixins": {
+                    "description": "Any class mixins applied in the extends clause of this class.\n\nIf mixins are applied in the class definition, then the true superclass\nof this class is the result of applying mixins in order to the superclass.\n\nMixins must be listed in order of their application to the superclass or\nprevious mixin application. This means that the innermost mixin is listed\nfirst. This may read backwards from the common order in JavaScript, but\nmatches the order of language used to describe mixin application, like\n\"S with A, B\".",
+                    "items": {
+                        "$ref": "#/definitions/Reference"
+                    },
+                    "type": "array"
                 },
                 "name": {
                     "type": "string"
                 },
-                "privacy": {
-                    "$ref": "#/definitions/Privacy"
+                "parameters": {
+                    "items": {
+                        "$ref": "#/definitions/Parameter"
+                    },
+                    "type": "array"
                 },
-                "reflects": {
-                    "description": "If the property reflects to an attribute.\n\nIf this is true, `attribute` must be defined.",
-                    "type": "boolean"
+                "return": {
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "$ref": "#/definitions/Type"
+                        }
+                    },
+                    "type": "object"
+                },
+                "slots": {
+                    "description": "The shadow dom content slots that this element accepts.",
+                    "items": {
+                        "$ref": "#/definitions/Slot"
+                    },
+                    "type": "array"
                 },
                 "source": {
                     "$ref": "#/definitions/SourceReference"
-                },
-                "static": {
-                    "type": "boolean"
                 },
                 "summary": {
                     "description": "A markdown summary suitable for display in a listing.",
                     "type": "string"
                 },
-                "type": {
-                    "$ref": "#/definitions/Type"
+                "superclass": {
+                    "$ref": "#/definitions/Reference",
+                    "description": "The superclass of this class.\n\nIf this class is defined with mixin\napplications, the prototype chain includes the mixin applications\nand the true superclass is computed from them."
+                },
+                "tagName": {
+                    "description": "An optional tag name that should be specified if this is a\nself-registering element.\n\nSelf-registering elements must also include a CustomElementExport\nin the module's exports.",
+                    "type": "string"
                 }
             },
             "required": [
+                "customElement",
                 "kind",
                 "name"
             ],
@@ -615,26 +691,10 @@
                                 "$ref": "#/definitions/VariableDeclaration"
                             },
                             {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/definitions/ClassDeclaration"
-                                    },
-                                    {
-                                        "$ref": "#/definitions/CustomElement"
-                                    }
-                                ],
-                                "description": "A description of a custom element class.\n\nCustom elements are JavaScript classes, so this extends from\n`ClassDeclaration` and adds custom-element-specific features like\nattributes, events, and slots.\n\nNote that `tagName` in this interface is optional. Tag names are not\nneccessarily part of a custom element class, but belong to the definition\n(often called the \"registration\") or the `customElements.define()` call.\n\nBecause classes and tag names can only be registered once, there's a\none-to-one relationship between classes and tag names. For ease of use,\nwe allow the tag name here.\n\nSome packages define and register custom elements in separate modules. In\nthese cases one `Module` should contain the `CustomElement` without a\ntagName, and another `Module` should contain the\n`CustomElementExport`."
+                                "$ref": "#/definitions/CustomElementDeclaration"
                             },
                             {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/definitions/MixinDeclaration"
-                                    },
-                                    {
-                                        "$ref": "#/definitions/CustomElement"
-                                    }
-                                ],
-                                "description": "A class mixin that also adds custom element related properties."
+                                "$ref": "#/definitions/CustomElementMixinDeclaration"
                             }
                         ]
                     },

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,992 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "Attribute": {
+            "properties": {
+                "default": {
+                    "description": "The default value of the attribute, if any.\n\nAs attributes are always strings, this is the actual value, not a human\nreadable description.",
+                    "type": "string"
+                },
+                "deprecated": {
+                    "description": "Whether the attribute is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "description": {
+                    "description": "A markdown description.",
+                    "type": "string"
+                },
+                "fieldName": {
+                    "description": "The name of the field this attribute is associated with, if any.",
+                    "type": "string"
+                },
+                "inheritedFrom": {
+                    "$ref": "#/definitions/Reference"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/Type",
+                    "description": "The type that the attribute will be serialized/deserialized as."
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "ClassDeclaration": {
+            "properties": {
+                "deprecated": {
+                    "description": "Whether the class or mixin is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "description": {
+                    "description": "A markdown description of the class.",
+                    "type": "string"
+                },
+                "kind": {
+                    "enum": [
+                        "class"
+                    ],
+                    "type": "string"
+                },
+                "members": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/ClassField"
+                            },
+                            {
+                                "$ref": "#/definitions/ClassMethod"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "mixins": {
+                    "description": "Any class mixins applied in the extends clause of this class.\n\nIf mixins are applied in the class definition, then the true superclass\nof this class is the result of applying mixins in order to the superclass.\n\nMixins must be listed in order of their application to the superclass or\nprevious mixin application. This means that the innermost mixin is listed\nfirst. This may read backwards from the common order in JavaScript, but\nmatches the order of language used to describe mixin application, like\n\"S with A, B\".",
+                    "items": {
+                        "$ref": "#/definitions/Reference"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source": {
+                    "$ref": "#/definitions/SourceReference"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                },
+                "superclass": {
+                    "$ref": "#/definitions/Reference",
+                    "description": "The superclass of this class.\n\nIf this class is defined with mixin\napplications, the prototype chain includes the mixin applications\nand the true superclass is computed from them."
+                }
+            },
+            "required": [
+                "kind",
+                "name"
+            ],
+            "type": "object"
+        },
+        "ClassField": {
+            "properties": {
+                "default": {
+                    "type": "string"
+                },
+                "deprecated": {
+                    "description": "Whether the property is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "description": {
+                    "description": "A markdown description of the field.",
+                    "type": "string"
+                },
+                "inheritedFrom": {
+                    "$ref": "#/definitions/Reference"
+                },
+                "kind": {
+                    "enum": [
+                        "field"
+                    ],
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "privacy": {
+                    "$ref": "#/definitions/Privacy"
+                },
+                "source": {
+                    "$ref": "#/definitions/SourceReference"
+                },
+                "static": {
+                    "type": "boolean"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/Type"
+                }
+            },
+            "required": [
+                "kind",
+                "name"
+            ],
+            "type": "object"
+        },
+        "ClassMethod": {
+            "properties": {
+                "description": {
+                    "description": "A markdown description.",
+                    "type": "string"
+                },
+                "inheritedFrom": {
+                    "$ref": "#/definitions/Reference"
+                },
+                "kind": {
+                    "enum": [
+                        "method"
+                    ],
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "items": {
+                        "$ref": "#/definitions/Parameter"
+                    },
+                    "type": "array"
+                },
+                "privacy": {
+                    "$ref": "#/definitions/Privacy"
+                },
+                "return": {
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "$ref": "#/definitions/Type"
+                        }
+                    },
+                    "type": "object"
+                },
+                "source": {
+                    "$ref": "#/definitions/SourceReference"
+                },
+                "static": {
+                    "type": "boolean"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "kind",
+                "name"
+            ],
+            "type": "object"
+        },
+        "CssCustomProperty": {
+            "properties": {
+                "default": {
+                    "type": "string"
+                },
+                "deprecated": {
+                    "description": "Whether the CSS custom property is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "description": {
+                    "description": "A markdown description.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name of the property, including leading `--`.",
+                    "type": "string"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                },
+                "syntax": {
+                    "description": "The expected syntax of the defined property. Defaults to \"*\".\n\nThe syntax must be a valid CSS [syntax string](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax)\nas defined in the CSS Properties and Values API.\n\nExamples:\n\n\"<color>\": accepts a color\n\"<length> | <percentage>\": accepts lengths or percentages but not calc expressions with a combination of the two\n\"small | medium | large\": accepts one of these values set as custom idents.\n\"*\": any valid token",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "CssPart": {
+            "description": "The description of a CSS Part",
+            "properties": {
+                "deprecated": {
+                    "description": "Whether the CSS shadow part is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "description": {
+                    "description": "A markdown description.",
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "CustomElement": {
+            "description": "The additional fields that a custom element adds to classes and mixins.",
+            "properties": {
+                "attributes": {
+                    "description": "The attributes that this element is known to understand.",
+                    "items": {
+                        "$ref": "#/definitions/Attribute"
+                    },
+                    "type": "array"
+                },
+                "cssParts": {
+                    "items": {
+                        "$ref": "#/definitions/CssPart"
+                    },
+                    "type": "array"
+                },
+                "cssProperties": {
+                    "items": {
+                        "$ref": "#/definitions/CssCustomProperty"
+                    },
+                    "type": "array"
+                },
+                "customElement": {
+                    "description": "Distinguishes a regular JavaScript class from a\ncustom element class",
+                    "enum": [
+                        true
+                    ],
+                    "type": "boolean"
+                },
+                "demos": {
+                    "items": {
+                        "$ref": "#/definitions/Demo"
+                    },
+                    "type": "array"
+                },
+                "deprecated": {
+                    "description": "Whether the custom element is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "description": {
+                    "description": "A markdown description of the class.",
+                    "type": "string"
+                },
+                "events": {
+                    "description": "The events that this element fires.",
+                    "items": {
+                        "$ref": "#/definitions/Event"
+                    },
+                    "type": "array"
+                },
+                "members": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/CustomElementField"
+                            },
+                            {
+                                "$ref": "#/definitions/ClassMethod"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "mixins": {
+                    "description": "Any class mixins applied in the extends clause of this class.\n\nIf mixins are applied in the class definition, then the true superclass\nof this class is the result of applying mixins in order to the superclass.\n\nMixins must be listed in order of their application to the superclass or\nprevious mixin application. This means that the innermost mixin is listed\nfirst. This may read backwards from the common order in JavaScript, but\nmatches the order of language used to describe mixin application, like\n\"S with A, B\".",
+                    "items": {
+                        "$ref": "#/definitions/Reference"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "slots": {
+                    "description": "The shadow dom content slots that this element accepts.",
+                    "items": {
+                        "$ref": "#/definitions/Slot"
+                    },
+                    "type": "array"
+                },
+                "source": {
+                    "$ref": "#/definitions/SourceReference"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                },
+                "superclass": {
+                    "$ref": "#/definitions/Reference",
+                    "description": "The superclass of this class.\n\nIf this class is defined with mixin\napplications, the prototype chain includes the mixin applications\nand the true superclass is computed from them."
+                },
+                "tagName": {
+                    "description": "An optional tag name that should be specified if this is a\nself-registering element.\n\nSelf-registering elements must also include a CustomElementExport\nin the module's exports.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "customElement",
+                "name"
+            ],
+            "type": "object"
+        },
+        "CustomElementExport": {
+            "description": "A global custom element defintion, ie the result of a\n`customElements.define()` call.\n\nThis is represented as an export because a definition makes the element\navailable outside of the module it's defined it.",
+            "properties": {
+                "declaration": {
+                    "$ref": "#/definitions/Reference",
+                    "description": "A reference to the class or other declaration that implements the\ncustom element."
+                },
+                "deprecated": {
+                    "description": "Whether the custom-element export is deprecated.\nFor example, a future version will not register the custom element in this file.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "kind": {
+                    "enum": [
+                        "custom-element-definition"
+                    ],
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The tag name of the custom element.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "declaration",
+                "kind",
+                "name"
+            ],
+            "type": "object"
+        },
+        "CustomElementField": {
+            "description": "Additional metadata for fields on custom elements.",
+            "properties": {
+                "attribute": {
+                    "description": "The corresponding attribute name if there is one.",
+                    "type": "string"
+                },
+                "default": {
+                    "type": "string"
+                },
+                "deprecated": {
+                    "description": "Whether the property is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "description": {
+                    "description": "A markdown description of the field.",
+                    "type": "string"
+                },
+                "inheritedFrom": {
+                    "$ref": "#/definitions/Reference"
+                },
+                "kind": {
+                    "enum": [
+                        "field"
+                    ],
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "privacy": {
+                    "$ref": "#/definitions/Privacy"
+                },
+                "reflects": {
+                    "description": "If the property reflects to an attribute.\n\nIf this is true, `attribute` must be defined.",
+                    "type": "boolean"
+                },
+                "source": {
+                    "$ref": "#/definitions/SourceReference"
+                },
+                "static": {
+                    "type": "boolean"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/Type"
+                }
+            },
+            "required": [
+                "kind",
+                "name"
+            ],
+            "type": "object"
+        },
+        "Demo": {
+            "properties": {
+                "description": {
+                    "description": "A markdown description of the demo.",
+                    "type": "string"
+                },
+                "source": {
+                    "$ref": "#/definitions/SourceReference"
+                },
+                "url": {
+                    "description": "Relative URL of the demo if it's published with the package. Absolute URL\nif it's hosted.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "url"
+            ],
+            "type": "object"
+        },
+        "Event": {
+            "properties": {
+                "deprecated": {
+                    "description": "Whether the event is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "description": {
+                    "description": "A markdown description.",
+                    "type": "string"
+                },
+                "inheritedFrom": {
+                    "$ref": "#/definitions/Reference"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/Type",
+                    "description": "The type of the event object that's fired."
+                }
+            },
+            "required": [
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "FunctionDeclaration": {
+            "properties": {
+                "description": {
+                    "description": "A markdown description.",
+                    "type": "string"
+                },
+                "kind": {
+                    "enum": [
+                        "function"
+                    ],
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "items": {
+                        "$ref": "#/definitions/Parameter"
+                    },
+                    "type": "array"
+                },
+                "return": {
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "$ref": "#/definitions/Type"
+                        }
+                    },
+                    "type": "object"
+                },
+                "source": {
+                    "$ref": "#/definitions/SourceReference"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "kind",
+                "name"
+            ],
+            "type": "object"
+        },
+        "JavaScriptExport": {
+            "properties": {
+                "declaration": {
+                    "$ref": "#/definitions/Reference",
+                    "description": "A reference to the exported declaration.\n\nIn the case of aggregating exports, the reference's `module` field must be\ndefined and the `name` field must be `\"*\"`."
+                },
+                "deprecated": {
+                    "description": "Whether the export is deprecated. For example, the name of the export was changed.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "kind": {
+                    "enum": [
+                        "js"
+                    ],
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name of the exported symbol.\n\nJavaScript has a number of ways to export objects which determine the\ncorrect name to use.\n\n- Default exports must use the name \"default\".\n- Named exports use the name that is exported. If the export is renamed\n  with the \"as\" clause, use the exported name.\n- Aggregating exports (`* from`) should use the name `*`",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "declaration",
+                "kind",
+                "name"
+            ],
+            "type": "object"
+        },
+        "JavaScriptModule": {
+            "properties": {
+                "declarations": {
+                    "description": "The declarations of a module.\n\nFor documentation purposes, all declarations that are reachable from\nexports should be described here. Ie, functions and objects that may be\nproperties of exported objects, or passed as arguments to functions.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/ClassDeclaration"
+                            },
+                            {
+                                "$ref": "#/definitions/FunctionDeclaration"
+                            },
+                            {
+                                "$ref": "#/definitions/MixinDeclaration"
+                            },
+                            {
+                                "$ref": "#/definitions/VariableDeclaration"
+                            },
+                            {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/definitions/ClassDeclaration"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/CustomElement"
+                                    }
+                                ],
+                                "description": "A description of a custom element class.\n\nCustom elements are JavaScript classes, so this extends from\n`ClassDeclaration` and adds custom-element-specific features like\nattributes, events, and slots.\n\nNote that `tagName` in this interface is optional. Tag names are not\nneccessarily part of a custom element class, but belong to the definition\n(often called the \"registration\") or the `customElements.define()` call.\n\nBecause classes and tag names can only be registered once, there's a\none-to-one relationship between classes and tag names. For ease of use,\nwe allow the tag name here.\n\nSome packages define and register custom elements in separate modules. In\nthese cases one `Module` should contain the `CustomElement` without a\ntagName, and another `Module` should contain the\n`CustomElementExport`."
+                            },
+                            {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/definitions/MixinDeclaration"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/CustomElement"
+                                    }
+                                ],
+                                "description": "A class mixin that also adds custom element related properties."
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "deprecated": {
+                    "description": "Whether the module is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "description": {
+                    "description": "A markdown description of the module.",
+                    "type": "string"
+                },
+                "exports": {
+                    "description": "The exports of a module. This includes JavaScript exports and\ncustom element definitions.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/JavaScriptExport"
+                            },
+                            {
+                                "$ref": "#/definitions/CustomElementExport"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "kind": {
+                    "enum": [
+                        "javascript-module"
+                    ],
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "kind",
+                "path"
+            ],
+            "type": "object"
+        },
+        "MixinDeclaration": {
+            "description": "A description of a class mixin.\n\nMixins are functions which generate a new subclass of a given superclass.\nThis interfaces describes the class and custom element features that\nare added by the mixin. As such, it extends the CustomElement interface and\nClassLike interface.\n\nSince mixins are functions, it also extends the FunctionLike interface. This\nmeans a mixin is callable, and has parameters and a return type.\n\nThe return type is often hard or impossible to accurately describe in type\nsystems like TypeScript. It requires generics and an `extends` operator\nthat TypeScript lacks. Therefore it's recommended that the return type is\nleft empty. The most common form of a mixin function takes a single\nargument, so consumers of this interface should assume that the return type\nis the single argument subclassed by this declaration.\n\nA mixin should not have a superclass. If a mixins composes other mixins,\nthey should be listed in the `mixins` field.\n\nSee [this article]{@linkhttps ://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/}for more information on the classmixin pattern in JavaScript.",
+            "properties": {
+                "deprecated": {
+                    "description": "Whether the class or mixin is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "description": {
+                    "description": "A markdown description of the class.",
+                    "type": "string"
+                },
+                "kind": {
+                    "enum": [
+                        "mixin"
+                    ],
+                    "type": "string"
+                },
+                "members": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/ClassField"
+                            },
+                            {
+                                "$ref": "#/definitions/ClassMethod"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "mixins": {
+                    "description": "Any class mixins applied in the extends clause of this class.\n\nIf mixins are applied in the class definition, then the true superclass\nof this class is the result of applying mixins in order to the superclass.\n\nMixins must be listed in order of their application to the superclass or\nprevious mixin application. This means that the innermost mixin is listed\nfirst. This may read backwards from the common order in JavaScript, but\nmatches the order of language used to describe mixin application, like\n\"S with A, B\".",
+                    "items": {
+                        "$ref": "#/definitions/Reference"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "items": {
+                        "$ref": "#/definitions/Parameter"
+                    },
+                    "type": "array"
+                },
+                "return": {
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "$ref": "#/definitions/Type"
+                        }
+                    },
+                    "type": "object"
+                },
+                "source": {
+                    "$ref": "#/definitions/SourceReference"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                },
+                "superclass": {
+                    "$ref": "#/definitions/Reference",
+                    "description": "The superclass of this class.\n\nIf this class is defined with mixin\napplications, the prototype chain includes the mixin applications\nand the true superclass is computed from them."
+                }
+            },
+            "required": [
+                "kind",
+                "name"
+            ],
+            "type": "object"
+        },
+        "Parameter": {
+            "properties": {
+                "default": {
+                    "type": "string"
+                },
+                "deprecated": {
+                    "description": "Whether the property is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "description": {
+                    "description": "A markdown description of the field.",
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "optional": {
+                    "description": "Whether the parameter is optional. Undefined implies non-optional.",
+                    "type": "boolean"
+                },
+                "rest": {
+                    "description": "Whether the parameter is a rest parameter. Only the last parameter may be a rest parameter.\nUndefined implies single parameter.",
+                    "type": "boolean"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/Type"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "Privacy": {
+            "enum": [
+                "private",
+                "protected",
+                "public"
+            ],
+            "type": "string"
+        },
+        "Reference": {
+            "description": "A reference to an export of a module.\n\nAll references are required to be publically accessible, so the canonical\nrepresentation of a reference is the export it's available from.\n\n`package` should generally refer to an npm package name. If `package` is\nundefined then the reference is local to this package. If `module` is\nundefined the reference is local to the containing module.\n\nReferences to global symbols like `Array`, `HTMLElement`, or `Event` should\nuse a `package` name of `\"global:\"`.",
+            "properties": {
+                "module": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "package": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "Slot": {
+            "properties": {
+                "deprecated": {
+                    "description": "Whether the slot is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "description": {
+                    "description": "A markdown description.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The slot name, or the empty string for an unnamed slot.",
+                    "type": "string"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "SourceReference": {
+            "description": "A reference to the source of a declaration or member.",
+            "properties": {
+                "href": {
+                    "description": "An absolute URL to the source (ie. a GitHub URL).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "href"
+            ],
+            "type": "object"
+        },
+        "Type": {
+            "properties": {
+                "references": {
+                    "description": "An array of references to the types in the type string.\n\nThese references have optional indices into the type string so that tools\ncan understand the references in the type string independently of the type\nsystem and syntax. For example, a documentation viewer could display the\ntype `Array<FooElement | BarElement>` with cross-references to `FooElement`\nand `BarElement` without understanding arrays, generics, or union types.",
+                    "items": {
+                        "$ref": "#/definitions/TypeReference"
+                    },
+                    "type": "array"
+                },
+                "source": {
+                    "$ref": "#/definitions/SourceReference"
+                },
+                "text": {
+                    "description": "The full string representation of the type, in whatever type syntax is\nused, such as JSDoc, Closure, or TypeScript.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "text"
+            ],
+            "type": "object"
+        },
+        "TypeReference": {
+            "description": "A reference that is associated with a type string and optionally a range\nwithin the string.\n\nStart and end must both be present or not present. If they're present, they\nare indices into the associated type string. If they are missing, the entire\ntype string is the symbol referenced and the name should match the type\nstring.",
+            "properties": {
+                "end": {
+                    "type": "number"
+                },
+                "module": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "package": {
+                    "type": "string"
+                },
+                "start": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "VariableDeclaration": {
+            "properties": {
+                "default": {
+                    "type": "string"
+                },
+                "deprecated": {
+                    "description": "Whether the property is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "description": {
+                    "description": "A markdown description of the field.",
+                    "type": "string"
+                },
+                "kind": {
+                    "enum": [
+                        "variable"
+                    ],
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source": {
+                    "$ref": "#/definitions/SourceReference"
+                },
+                "summary": {
+                    "description": "A markdown summary suitable for display in a listing.",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/Type"
+                }
+            },
+            "required": [
+                "kind",
+                "name"
+            ],
+            "type": "object"
+        }
+    },
+    "description": "The top-level interface of a custom elements manifest file.\n\nBecause custom elements are JavaScript classes, describing a custom element\nmay require describing arbitrary JavaScript concepts like modules, classes,\nfunctions, etc. So custom elements manifests are capable of documenting\nthe elements in a package, as well as those JavaScript concepts.\n\nThe modules described in a package should be the public entrypoints that\nother packages may import from. Multiple modules may export the same object\nvia re-exports, but in most cases a package should document the single\ncanonical export that should be used.",
+    "properties": {
+        "deprecated": {
+            "description": "Whether the package is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+            "type": [
+                "string",
+                "boolean"
+            ]
+        },
+        "modules": {
+            "description": "An array of the modules this package contains.",
+            "items": {
+                "$ref": "#/definitions/JavaScriptModule"
+            },
+            "type": "array"
+        },
+        "readme": {
+            "description": "The Markdown to use for the main readme of this package.\n\nThis can be used to override the readme used by Github or npm if that\nfile contains information irrelevant to custom element catalogs and\ndocumentation viewers.",
+            "type": "string"
+        },
+        "schemaVersion": {
+            "description": "The version of the schema used in this file.",
+            "type": "string"
+        }
+    },
+    "required": [
+        "modules",
+        "schemaVersion"
+    ],
+    "type": "object"
+}
+

--- a/src/test/schema_test.ts
+++ b/src/test/schema_test.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {test} from 'uvu';
+import * as assert from 'uvu/assert';
+import {Validator} from 'jsonschema';
+import * as fs from 'fs/promises';
+
+const schema = JSON.parse(await fs.readFile('./schema.json', 'utf-8'));
+
+test('Schema tests', async () => {
+  // TODO: read multiple test files
+  const example = JSON.parse(
+    await fs.readFile('./examples/simple-element.json', 'utf-8')
+  );
+  const validator = new Validator();
+  const result = validator.validate(example, schema);
+  assert.is(result.errors.length, 0);
+});
+
+test.run();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "rootDir": "./src/",
     "outDir": "./",
     "strict": true,
     "noUnusedLocals": true,
@@ -14,6 +15,6 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
   },
-  "include": ["*.ts"],
+  "include": ["schema.d.ts", "src/**/*.ts"],
   "exclude": []
 }


### PR DESCRIPTION
Fixes https://github.com/webcomponents/custom-elements-manifest/issues/100

* Checks in `schema.json` so we can review changes to it directly
* Adds GitHub action to ensure `schema.json` is built
* Adds an example to `/examples`
* Changes `CustomElementDeclaration` and `CustomElementMixinDeclaration` to interfaces so they generate named schemas
* Adds a test of the example schema

I recommend reviewing each commit separately.