### PR TITLE
Add `deprecated` to FunctionLike

### DIFF
--- a/schema.d.ts
+++ b/schema.d.ts
@@ -257,14 +257,6 @@ export interface CustomElement extends ClassLike {
    * custom element class
    */
   customElement: true;
-
-  // members?: Array<CustomElementMember>;
-
-  /**
-   * Whether the custom element is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: boolean | string;
 }
 
 export interface Attribute {
@@ -694,6 +686,12 @@ export interface FunctionLike {
    * A markdown description.
    */
   description?: string;
+
+  /**
+   * Whether the function is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
 
   parameters?: Parameter[];
 

--- a/schema.json
+++ b/schema.json
@@ -155,6 +155,13 @@
         },
         "ClassMethod": {
             "properties": {
+                "deprecated": {
+                    "description": "Whether the function is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
                 "description": {
                     "description": "A markdown description.",
                     "type": "string"
@@ -597,6 +604,13 @@
         },
         "FunctionDeclaration": {
             "properties": {
+                "deprecated": {
+                    "description": "Whether the function is deprecated.\nIf the value is a string, it's the reason for the deprecation.",
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
                 "description": {
                     "description": "A markdown description.",
                     "type": "string"
@@ -732,6 +746,7 @@
                     "type": "string"
                 },
                 "path": {
+                    "description": "Path to the javascript file needed to be imported. \n(not the path for example to a typescript file.)",
                     "type": "string"
                 },
                 "summary": {


### PR DESCRIPTION
Also clean up a redundant `deprecated` that resulted from a bad rebase.

Doing this instead of #98 in order to update the newly checked-in schema.json file.