### PR TITLE
Clarify reflected attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
-<!-- ## [x.y.z] - YYYY-MM-DD -->
+## Unreleased
+
+### Fixed
+
+- Clarified that all attributes of a `CustomElement` must be listed in the the `attributes` array, even those reflected from a `CustomElementField`.
 
 ## [2.0.0] - 2022-09-12
 

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -466,9 +466,9 @@ export interface ClassLike {
   /**
    * The superclass of this class.
    *
-   * If this class is defined with mixin
-   * applications, the prototype chain includes the mixin applications
-   * and the true superclass is computed from them.
+   * If this class is defined with mixin applications, the prototype chain
+   * includes the mixin applications and the true superclass is computed
+   * from them.
    */
   superclass?: Reference;
 
@@ -573,13 +573,16 @@ export interface ClassField extends PropertyLike {
 export interface CustomElementField extends ClassField {
   /**
    * The corresponding attribute name if there is one.
+   * 
+   * If this property is defined, the attribute must be listed in the classes'
+   * `attributes` array.
    */
   attribute?: string;
 
   /**
    * If the property reflects to an attribute.
    *
-   * If this is true, `attribute` must be defined.
+   * If this is true, the `attribute` property must be defined.
    */
   reflects?: boolean;
 }

--- a/schema.json
+++ b/schema.json
@@ -93,7 +93,7 @@
                 },
                 "superclass": {
                     "$ref": "#/definitions/Reference",
-                    "description": "The superclass of this class.\n\nIf this class is defined with mixin\napplications, the prototype chain includes the mixin applications\nand the true superclass is computed from them."
+                    "description": "The superclass of this class.\n\nIf this class is defined with mixin applications, the prototype chain\nincludes the mixin applications and the true superclass is computed\nfrom them."
                 }
             },
             "required": [
@@ -383,7 +383,7 @@
                 },
                 "superclass": {
                     "$ref": "#/definitions/Reference",
-                    "description": "The superclass of this class.\n\nIf this class is defined with mixin\napplications, the prototype chain includes the mixin applications\nand the true superclass is computed from them."
+                    "description": "The superclass of this class.\n\nIf this class is defined with mixin applications, the prototype chain\nincludes the mixin applications and the true superclass is computed\nfrom them."
                 },
                 "tagName": {
                     "description": "An optional tag name that should be specified if this is a\nself-registering element.\n\nSelf-registering elements must also include a CustomElementExport\nin the module's exports.",
@@ -549,7 +549,7 @@
                 },
                 "superclass": {
                     "$ref": "#/definitions/Reference",
-                    "description": "The superclass of this class.\n\nIf this class is defined with mixin\napplications, the prototype chain includes the mixin applications\nand the true superclass is computed from them."
+                    "description": "The superclass of this class.\n\nIf this class is defined with mixin applications, the prototype chain\nincludes the mixin applications and the true superclass is computed\nfrom them."
                 },
                 "tagName": {
                     "description": "An optional tag name that should be specified if this is a\nself-registering element.\n\nSelf-registering elements must also include a CustomElementExport\nin the module's exports.",
@@ -853,7 +853,7 @@
                 },
                 "superclass": {
                     "$ref": "#/definitions/Reference",
-                    "description": "The superclass of this class.\n\nIf this class is defined with mixin\napplications, the prototype chain includes the mixin applications\nand the true superclass is computed from them."
+                    "description": "The superclass of this class.\n\nIf this class is defined with mixin applications, the prototype chain\nincludes the mixin applications and the true superclass is computed\nfrom them."
                 }
             },
             "required": [


### PR DESCRIPTION
This came up with @bennypowers's work on the Lit Analyzer. It wasn't clear that all attributes should be listed in the attributes array. Doing so is explicit, and makes it easy for a tool to gather attribute info, including types, without needing to infer the specifics of how a particular element reflects a property.